### PR TITLE
Fix a typo in the cache.

### DIFF
--- a/usr/etc/laporte/cache
+++ b/usr/etc/laporte/cache
@@ -2,7 +2,7 @@
   urls = {
     "https://raw.githubusercontent.com/TARDIX/Chameleon/master/laporte_index",
   },
-  pack  ages = {
+  packages = {
     {
       desc = "Simple package manager for Chameleon.",
       files = {


### PR DESCRIPTION
change "pack ages" to "packages"